### PR TITLE
年間スケジュールページを追加

### DIFF
--- a/app/src/app/annual-schedule/_components/annual-schedule-card.tsx
+++ b/app/src/app/annual-schedule/_components/annual-schedule-card.tsx
@@ -1,0 +1,31 @@
+import Image, { type StaticImageData } from "next/image";
+
+type AnnualScheduleCardProps = {
+  months: string[];
+  image: StaticImageData;
+  alt: string;
+  title: string;
+};
+
+export const AnnualScheduleCard = ({
+  months,
+  image,
+  alt,
+  title,
+}: AnnualScheduleCardProps) => {
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-4">
+        <div className="h-1 w-[28px] md:w-[274px] bg-gradient-to-r from-primary to-secondary" />
+        <h2 className="text-lg md:text-xl font-bold leading-normal text-primary">
+          {months.join("・")}：{title}
+        </h2>
+      </div>
+      <Image
+        src={image}
+        alt={alt}
+        className="ml-[28px] md:ml-[274px] max-w-[50vw] md:max-w-[32vw]"
+      />
+    </div>
+  );
+};

--- a/app/src/app/annual-schedule/_components/yearly-archive.tsx
+++ b/app/src/app/annual-schedule/_components/yearly-archive.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+
+export const YearlyArchive = () => {
+  const years = [2025, 2024, 2023, 2022, 2021];
+
+  return (
+    <aside className="sticky top-[100px]">
+      <h2 className="mb-4 text-lg md:text-xl font-semibold leading-[25px] text-primary">
+        年別アーカイブ
+      </h2>
+      <nav>
+        <ul className="space-y-[15px] md:space-y-[30px]">
+          {years.map((year) => (
+            <li key={year}>
+              <Link
+                href={`/annual-schedule?year=${year}`}
+                className="bg-white rounded-[9px] md:rounded-[18px] border-[1px] px-[25px] md:px-[50px] py-[10px] border-primary block text-base font-semibold leading-[25px] text-primary transition-opacity hover:opacity-80 text-center"
+              >
+                {year}年
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+};

--- a/app/src/app/annual-schedule/page.tsx
+++ b/app/src/app/annual-schedule/page.tsx
@@ -1,0 +1,115 @@
+import Image, { type StaticImageData } from "next/image";
+import Link from "next/link";
+import CarouselImage1 from "@/assets/carousel/carousel-1.jpg";
+import CarouselImage2 from "@/assets/carousel/carousel-2.jpg";
+import CarouselImage3 from "@/assets/carousel/carousel-3.jpg";
+import BackIcon from "@/assets/guide-button/back.svg";
+import Activity1 from "@/assets/internal-link/activity-1.jpg";
+import PresentationImage from "@/assets/mvv/presentation.jpg";
+import FounderMessage from "@/assets/sections/history/founder-message.png";
+import { PageBackground } from "@/components/page-background";
+import { AnnualScheduleCard } from "./_components/annual-schedule-card";
+import { YearlyArchive } from "./_components/yearly-archive";
+
+type AnnualSchedule = {
+  months: string[];
+  image: StaticImageData;
+  alt: string;
+  title: string;
+};
+
+const annualSchedules: AnnualSchedule[] = [
+  {
+    months: ["4月", "5月"],
+    image: CarouselImage1,
+    alt: "新入生歓迎イベント",
+    title: "新入生歓迎・春季プロジェクト始動",
+  },
+  {
+    months: ["6月", "7月"],
+    image: PresentationImage,
+    alt: "ビジネスコンテスト準備",
+    title: "ビジコン準備・夏季フィールドワーク",
+  },
+  {
+    months: ["8月", "9月"],
+    image: CarouselImage2,
+    alt: "夏季ボランティア活動",
+    title: "夏季集中プロジェクト・ボランティア",
+  },
+  {
+    months: ["10月", "11月"],
+    image: FounderMessage,
+    alt: "早稲田祭出店",
+    title: "早稲田祭出店・秋季講演会",
+  },
+  {
+    months: ["12月", "1月"],
+    image: CarouselImage3,
+    alt: "年末年始活動",
+    title: "年次報告会・冬季プロジェクト",
+  },
+  {
+    months: ["2月", "3月"],
+    image: Activity1,
+    alt: "春季準備活動",
+    title: "次年度準備・春季合宿",
+  },
+];
+
+const Page = async () => {
+  const selectedYear = 2025;
+
+  return (
+    <div className="flex justify-between pt-[46px] pb-[136px] md:py-[150px] gap-[18px] relative">
+      <div className="max-w-[1190px] w-[70vw] z-2">
+        <div className="relative rounded-r-[18px] md:rounded-r-[70px] bg-white pt-[66px] pb-[112px]">
+          <div className="mb-12 md:mb-[115px]">
+            <div className="mb-2 flex items-center gap-4">
+              <div className="h-1 w-[28px] md:w-[128px] bg-gradient-to-r from-primary to-secondary" />
+              <h1 className="text-lg md:text-xl font-bold leading-normal text-primary">
+                {selectedYear}年 年間スケジュール
+              </h1>
+            </div>
+          </div>
+
+          <div className="space-y-16 mr-9 md:mr-36">
+            {annualSchedules.map((schedule) => (
+              <AnnualScheduleCard
+                key={schedule.title}
+                months={schedule.months}
+                image={schedule.image}
+                alt={schedule.alt}
+                title={schedule.title}
+              />
+            ))}
+          </div>
+
+          <div className="mt-12 flex justify-center md:mt-[216px]">
+            <Link
+              href="/"
+              className="group inline-flex h-[42px] md:h-[55px] w-auto md:w-full max-w-[333px] items-center justify-between rounded-[27.5px] bg-gradient-to-r from-primary to-secondary px-[15px] md:px-6 md:text-[24px] font-bold text-white transition-opacity hover:opacity-90"
+            >
+              <Image
+                src={BackIcon}
+                alt=""
+                width={21}
+                height={21}
+                className="h-[21px] w-[21px] md:h-[27px] md:w-[27px]"
+              />
+              <span>メインページに戻る</span>
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div className="mr-[25px] md:mr-36">
+        <YearlyArchive />
+      </div>
+
+      <PageBackground />
+    </div>
+  );
+};
+
+export default Page;

--- a/app/src/app/projects/page.tsx
+++ b/app/src/app/projects/page.tsx
@@ -1,10 +1,8 @@
 import Image from "next/image";
 import Link from "next/link";
 import BackIcon from "@/assets/guide-button/back.svg";
-import BackgroundPattern from "@/assets/logo/background-pattern.svg";
-import BackgroundPatternWhite from "@/assets/logo/background-pattern-white.svg";
-import Bridges from "@/assets/logo/bridges.svg";
 import { getProjects } from "@/lib/microcms";
+import { PageBackground } from "../../components/page-background";
 import { MonthlyArchive } from "./_components/monthly-archive";
 import { ProjectOverviewCard } from "./_components/project-overview-card";
 
@@ -67,25 +65,7 @@ const Page = async () => {
         <MonthlyArchive projects={projects} />
       </div>
 
-      <Image
-        src={Bridges}
-        alt=""
-        width={1185}
-        height={187}
-        className="w-full absolute bottom-0 overflow-hidden"
-      />
-      <Image
-        src={BackgroundPattern}
-        alt=""
-        height={250}
-        className="h-[250px] md:h-[1080px] w-auto absolute bottom-0 right-0"
-      />
-      <Image
-        src={BackgroundPatternWhite}
-        alt=""
-        height={200}
-        className="h-[200px] md:h-[720px] w-auto absolute top-[250px] md:top-[140px] right-0"
-      />
+      <PageBackground />
     </div>
   );
 };

--- a/app/src/components/page-background.tsx
+++ b/app/src/components/page-background.tsx
@@ -1,0 +1,30 @@
+import Image from "next/image";
+import BackgroundPattern from "@/assets/logo/background-pattern.svg";
+import BackgroundPatternWhite from "@/assets/logo/background-pattern-white.svg";
+import Bridges from "@/assets/logo/bridges.svg";
+
+export const PageBackground = () => {
+  return (
+    <>
+      <Image
+        src={Bridges}
+        alt=""
+        width={1185}
+        height={187}
+        className="w-full absolute bottom-0 overflow-hidden"
+      />
+      <Image
+        src={BackgroundPattern}
+        alt=""
+        height={250}
+        className="h-[250px] md:h-[1080px] w-auto absolute bottom-0 right-0"
+      />
+      <Image
+        src={BackgroundPatternWhite}
+        alt=""
+        height={200}
+        className="h-[200px] md:h-[720px] w-auto absolute top-[250px] md:top-[140px] right-0"
+      />
+    </>
+  );
+};


### PR DESCRIPTION
- 年間スケジュールページ（/annual-schedule）を実装
- 年別アーカイブコンポーネントを追加（2021-2025年対応）
- 年間スケジュールカードコンポーネントを作成
- PageBackgroundコンポーネントを共通化してプロジェクトページでも使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 概要
<!-- このPRの目的を簡潔に説明してください -->

## 関連Issue
<!-- 関連するIssueがあればリンクしてください -->
Closes #

## 変更内容
<!-- 主な変更点を箇条書きで記載してください -->
-

## スクリーンショット
<!-- UI変更がある場合はスクリーンショットを添付してください -->

## AIレビュー内容
<!-- /reviewでAIエージェントに行わせたレビュー内容を添付してください -->

## 補足事項
<!-- その他、レビュアーに伝えたいことがあれば記載してください -->
